### PR TITLE
Fix pushing env file to GitHub

### DIFF
--- a/SeekJob/.env
+++ b/SeekJob/.env
@@ -1,2 +1,0 @@
-VITE_ENDPOINT = https://cloud.appwrite.io/v1
-VITE_PROJECT_ID = 66cde5f900188f1e8fc6

--- a/SeekJob/.env.example
+++ b/SeekJob/.env.example
@@ -1,0 +1,2 @@
+VITE_ENDPOINT=appwrite_endpoint
+VITE_PROJECT_ID=appwrite_project_id

--- a/SeekJob/.gitignore
+++ b/SeekJob/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment Variables for Appwrite
+.env


### PR DESCRIPTION
## Problem

I noticed you pushed the .env file to GitHub. As a good practice, you don't push .env files to your project. I can easily manipulate your database in the future due to having the .env values which is not good. `.env` files contain secret keys that should not be leaked.

## Solution
- I added `.env` to your `.gitignore` file
- I also created `.env.example` to help developers know the values needed when they clone your project.
- **I also deleted the `.env ` file**

## Action Items

- Keep your `.env ` file locally in a safe place.
- Merge this pull request and check the changes before merging
- I generally didn't touch any logic of the code and could not pass seeing you push .env codes to GitHub
- Do `git rm --cached` to remove the instances of .env in your staged files

> [!WARNING]  
> Never Push .env files to GitHub Again